### PR TITLE
Richer package import

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,33 @@
 "Related" means the package passed to `tdiff` and all recursively reachable packages.
 
 ### List related packages changed since the given SHA
+
 ```
 tdiff -package your/app/list_utils -sha OLDER_GIT_SHA -packages
 ```
 
 ### List related files changed since the given SHA
+
 ```
 tdiff -package your/app/list_utils -sha OLDER_GIT_SHA -files
 ```
+
 ### List Git commits since the given SHA that contain changes to related files
+
 ```
 tdiff -package your/app/list_utils -sha OLDER_GIT_SHA -commits
 ```
+
+### Get JSON output for all of the above, and more
+
+```
+tdiff -package your/app/list_utils -sha OLDER_GIT_SHA -json
+```
+
+The JSON output includes separate sections for packages, files, and commits.
+
+Additionally, each changed package also includes a path indicating how it is reachable from the given root path.
+
 
 # Notes
 

--- a/importer/graph.go
+++ b/importer/graph.go
@@ -1,0 +1,120 @@
+package importer
+
+import (
+	"fmt"
+	"go/build"
+	"sort"
+)
+
+// Path is an immutable path from one Go Package.
+// A path of [A B C] represents: "A imports package B and B imports package C".
+type Path []string
+
+// Append creates a new Path with the part appended to it.
+// [A B].Append(C) returns [A B C].
+func (p Path) Append(part string) Path {
+	newPath := make(Path, len(p)+1)
+	copy(newPath, p)
+	newPath[len(p)] = part
+
+	return newPath
+}
+
+// Package wraps a Go build.Package and adds additional data about how paths
+// used to import vendored dependencies.
+type Package struct {
+	*build.Package
+
+	ImportVendoredPaths map[string]string // Package dep import path to real vendored import path
+}
+
+// AllImports returns a list of all package import paths imported by the current package.
+// If vendored is true, the import paths returned will be the actual paths the Go build tool
+// resolves.
+func (p *Package) AllImports(vendored bool) []string {
+	importPaths := append(append(append([]string(nil), p.Imports...), p.TestImports...), p.XTestImports...)
+
+	if vendored {
+		for i, importPath := range importPaths {
+			// Check existence in ImportVendoredPaths due to "C" package
+			if _, ok := p.ImportVendoredPaths[importPath]; ok {
+				importPaths[i] = p.ImportVendoredPaths[importPath]
+			}
+		}
+	}
+
+	return importPaths
+}
+
+// PackageGraph represents all Go packages reachable from a single package.
+type PackageGraph struct {
+	Packages map[string]*Package // Packages, keyed by the vendored import path
+}
+
+// ToMap returns a map of package names to the package names of all dependencies.
+// The dependencies are vendored import paths.
+func (p *PackageGraph) ToMap() map[string][]string {
+	depMap := make(map[string][]string)
+	for name, pkg := range p.Packages {
+		deps := make([]string, 0, len(pkg.ImportVendoredPaths))
+		for _, importPath := range pkg.ImportVendoredPaths {
+			deps = append(deps, importPath)
+		}
+		sort.Strings(deps)
+		depMap[name] = deps
+	}
+
+	return depMap
+}
+
+// GoPackages returns all build.Packages in the graph.
+func (p *PackageGraph) GoPackages() []*build.Package {
+	packages := make([]*build.Package, 0, len(p.Packages))
+
+	for _, pkg := range p.Packages {
+		packages = append(packages, pkg.Package)
+	}
+
+	return packages
+}
+
+// ShortestPath returns the shortest import path from one package to another.
+// If there is no path between the packages then nil is returned.
+// If there are multiple equally short paths, the path chosen to return is not deterministic.
+// If either the from or to package does not exist, an error is returned.
+func (p *PackageGraph) ShortestPath(from, to string) (Path, error) {
+	if _, ok := p.Packages[from]; !ok {
+		return nil, fmt.Errorf("Import path `%s` does not exist in graph", from)
+	}
+	if _, ok := p.Packages[to]; !ok {
+		return nil, fmt.Errorf("Import path `%s` does not exist in graph", to)
+	}
+
+	visited := make(map[string]bool)
+	pathQueue := []Path{Path([]string{from})}
+	for len(pathQueue) > 0 {
+		curPath := pathQueue[0]
+		pathQueue = pathQueue[1:]
+
+		lastImportPath := curPath[len(curPath)-1]
+		if lastImportPath == to {
+			return curPath, nil
+		}
+		if lastImportPath == "C" {
+			continue
+		}
+		lastPkg, ok := p.Packages[lastImportPath]
+		if !ok {
+			return nil, fmt.Errorf("Unexpected: package `%s` does not exist in graph (path=%v)", lastImportPath, curPath)
+		}
+
+		for _, importName := range lastPkg.AllImports(true) {
+			if !visited[importName] {
+				visited[importName] = true
+				pathQueue = append(pathQueue, curPath.Append(importName))
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/importer/graph_test.go
+++ b/importer/graph_test.go
@@ -1,0 +1,73 @@
+package importer
+
+import (
+	"fmt"
+	"go/build"
+	"reflect"
+	"testing"
+)
+
+func TestShortestPast(t *testing.T) {
+	addFakePackage := func(graph *PackageGraph, name string, imports ...string) *Package {
+		pkg := &Package{
+			Package: &build.Package{
+				ImportPath: name,
+				Imports:    imports,
+			},
+			ImportVendoredPaths: make(map[string]string),
+		}
+
+		for _, importPath := range imports {
+			pkg.ImportVendoredPaths[importPath] = importPath
+		}
+
+		graph.Packages[name] = pkg
+
+		return pkg
+	}
+
+	// A -> [B, G]
+	// B -> [G]
+	// G -> [D]
+	// D -> []
+	// X -> [B, Y]
+	// Y -> []
+	graph := &PackageGraph{Packages: make(map[string]*Package)}
+	addFakePackage(graph, "A", "B", "G")
+	addFakePackage(graph, "B", "G")
+	addFakePackage(graph, "G", "D")
+	addFakePackage(graph, "D")
+	addFakePackage(graph, "X", "Y", "B")
+	addFakePackage(graph, "Y")
+
+	testCases := []struct {
+		from string
+		to   string
+		path []string
+	}{
+		{from: "A", to: "A", path: []string{"A"}},
+		{from: "A", to: "B", path: []string{"A", "B"}},
+		{from: "A", to: "G", path: []string{"A", "G"}},
+		{from: "A", to: "D", path: []string{"A", "G", "D"}},
+		{from: "X", to: "A", path: nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("from=%s to=%s path=%v", tc.from, tc.to, tc.path), func(t *testing.T) {
+			path, err := graph.ShortestPath(tc.from, tc.to)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if expectedPath := Path(tc.path); !reflect.DeepEqual(expectedPath, path) {
+				t.Fatalf("Expected path %v but got %v", tc.path, path)
+			}
+		})
+	}
+
+	if _, err := graph.ShortestPath("A", "does not exist"); err == nil {
+		t.Errorf("Expected error but got none")
+	}
+	if _, err := graph.ShortestPath("does not exist", "A"); err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -1,0 +1,157 @@
+package importer
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"strings"
+)
+
+// DefaultRecursiveImport imports a Go package and all of its reachable dependencies.
+// The environment's GOPATH and default build context are used.
+func DefaultRecursiveImport(importPath string) (*PackageGraph, error) {
+	buildCtx := build.Default
+	return RecursiveImport(importPath, os.Getenv("GOPATH"), &buildCtx)
+}
+
+// RecursiveImport imports a Go package and all of its reachable dependencies.
+func RecursiveImport(importPath string, goPath string, buildContext *build.Context) (*PackageGraph, error) {
+	importer := newRecursiveImporter(goPath, buildContext)
+	if err := importer.importPackage(nil, importPath); err != nil {
+		return nil, err
+	}
+
+	return &PackageGraph{
+		Packages: importer.packages,
+	}, nil
+}
+
+type recursiveImporter struct {
+	goPath       string
+	buildContext *build.Context
+	packages     map[string]*Package
+}
+
+func newRecursiveImporter(goPath string, buildContext *build.Context) *recursiveImporter {
+	return &recursiveImporter{
+		goPath:       goPath,
+		buildContext: buildContext,
+		packages:     make(map[string]*Package),
+	}
+}
+
+// importPackage imports the package identified by importPath.
+// If parentPkg is given, it uses the parent package's import path to determine
+// possible vendored packages to import for importPath.
+func (r *recursiveImporter) importPackage(parentPkg *Package, importPath string) error {
+	pkg, err := r.vendoredImport(parentPkg, importPath)
+	if err != nil {
+		return err
+	} else if pkg == nil {
+		return nil
+	}
+
+	if err := r.importAll(pkg, pkg.Imports); err != nil {
+		return err
+	}
+
+	if err := r.importAll(pkg, pkg.TestImports); err != nil {
+		return err
+	}
+
+	return r.importAll(pkg, pkg.XTestImports)
+}
+
+func (r *recursiveImporter) importAll(parentPkg *Package, importPaths []string) error {
+	for _, importPath := range importPaths {
+		if err := r.importPackage(parentPkg, importPath); err != nil {
+			return fmt.Errorf("%s > %v", packageImportPath(parentPkg), err)
+		}
+	}
+
+	return nil
+}
+
+// vendoredImport attempts to import a possibly vendored package relative to a parent package.
+// If the package does not exist, nil is returned.
+func (r *recursiveImporter) vendoredImport(parentPkg *Package, importPath string) (*Package, error) {
+	// Ignore cgo import
+	if importPath == "C" {
+		return nil, nil
+	}
+
+	possibleImportPaths := vendorPaths(importPath, packageImportPath(parentPkg))
+
+	var goPkg *build.Package
+	var lastErr error
+	for _, possibleImportPath := range possibleImportPaths {
+		if _, ok := r.packages[possibleImportPath]; ok {
+			parentPkg.ImportVendoredPaths[importPath] = possibleImportPath
+			return nil, nil
+		}
+
+		goPkg, lastErr = r.rawImport(possibleImportPath)
+		if lastErr == nil {
+			pkg := &Package{
+				Package:             goPkg,
+				ImportVendoredPaths: make(map[string]string),
+			}
+			if parentPkg != nil {
+				parentPkg.ImportVendoredPaths[importPath] = possibleImportPath
+			}
+			r.packages[possibleImportPath] = pkg
+			return pkg, nil
+		}
+	}
+	return nil, lastErr
+}
+
+// rawImport attempts to import a build.Package based on an import path.
+// If the package does not exist, nil is returned.
+func (r *recursiveImporter) rawImport(importPath string) (*build.Package, error) {
+	// https: //github.com/golang/go/issues/17326
+	lookupName := importPath
+	if strings.HasPrefix(importPath, "golang_org/") {
+		lookupName = fmt.Sprintf("vendor/%s", importPath)
+	}
+
+	pkg, err := r.buildContext.Import(lookupName, r.goPath, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pkg.Name) == 0 {
+		return nil, nil
+	}
+
+	return pkg, nil
+}
+
+func packageImportPath(pkg *Package) string {
+	if pkg == nil {
+		return ""
+	}
+
+	return pkg.ImportPath
+}
+
+// vendorPaths returns all possible import paths for a package.
+// importPath is the import path of the package to import, and
+// fromImportPath is the parent package that is importing the package identified by importPath.
+//
+// For example, if package "a/b" (fromImportPath="a/b") wants to import packageName="target", it
+// may try the following ordered vendored import paths:
+// [a/b/vendor/target, a/vendor/target, vendor/target, target]
+func vendorPaths(importPath, fromImportPath string) []string {
+	var parts []string
+	if len(fromImportPath) > 0 {
+		parts = strings.Split(fromImportPath, "/")
+	}
+
+	paths := make([]string, 0, len(parts)+2)
+	for i := len(parts); i >= 0; i-- {
+		paths = append(paths, strings.Join(append(append(parts[0:i], "vendor"), importPath), "/"))
+	}
+
+	return append(paths, importPath)
+}

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -1,0 +1,96 @@
+package importer
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestRecursiveImport(t *testing.T) {
+	graph, err := DefaultRecursiveImport("github.com/alecholmes/tdiff/importer/test_packages/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDepMap := map[string][]string{
+		"github.com/alecholmes/tdiff/importer/test_packages/a": []string{
+			"github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa",
+			"github.com/alecholmes/tdiff/importer/test_packages/b",
+			"github.com/alecholmes/tdiff/importer/test_packages/vendor/p",
+		},
+		"github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa": []string{
+			"github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa/vendor/p",
+			"github.com/alecholmes/tdiff/importer/test_packages/b",
+		},
+		"github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa/vendor/p": []string{},
+		"github.com/alecholmes/tdiff/importer/test_packages/b": []string{
+			"unsafe",
+		},
+		"github.com/alecholmes/tdiff/importer/test_packages/vendor/p": []string{},
+		"unsafe": []string{},
+	}
+	if actual := graph.ToMap(); !reflect.DeepEqual(expectedDepMap, actual) {
+		t.Fatalf("Expected dep graph `%v` but got `%v`", expectedDepMap, actual)
+	}
+
+	expectedAPaths := map[string]string{
+		"github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa": "github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa",
+		"github.com/alecholmes/tdiff/importer/test_packages/b":        "github.com/alecholmes/tdiff/importer/test_packages/b",
+		"p": "github.com/alecholmes/tdiff/importer/test_packages/vendor/p",
+	}
+	if actual := graph.Packages["github.com/alecholmes/tdiff/importer/test_packages/a"].ImportVendoredPaths; !reflect.DeepEqual(actual, expectedAPaths) {
+		t.Errorf("Expected ImportVendoredPaths %v but got %v", expectedAPaths, actual)
+	}
+
+	expectedAAAPaths := map[string]string{
+		"p": "github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa/vendor/p",
+		"github.com/alecholmes/tdiff/importer/test_packages/b": "github.com/alecholmes/tdiff/importer/test_packages/b",
+	}
+	if actual := graph.Packages["github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa"].ImportVendoredPaths; !reflect.DeepEqual(actual, expectedAAAPaths) {
+		t.Errorf("Expected ImportVendoredPaths %v but got %v", expectedAAAPaths, actual)
+	}
+}
+
+func TestVendorPaths(t *testing.T) {
+	testCases := []struct {
+		packageName      string
+		importPath       string
+		expectedPackages []string
+	}{
+		{
+			packageName: "x/y",
+			importPath:  "",
+			expectedPackages: []string{
+				"vendor/x/y",
+				"x/y",
+			},
+		},
+		{
+			packageName: "x/y",
+			importPath:  "a",
+			expectedPackages: []string{
+				"a/vendor/x/y",
+				"vendor/x/y",
+				"x/y",
+			},
+		},
+		{
+			packageName: "x/y",
+			importPath:  "a/b",
+			expectedPackages: []string{
+				"a/b/vendor/x/y",
+				"a/vendor/x/y",
+				"vendor/x/y",
+				"x/y",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("packageName=%s importPath=%s", tc.packageName, tc.importPath), func(t *testing.T) {
+			if actualPaths := vendorPaths(tc.packageName, tc.importPath); !reflect.DeepEqual(tc.expectedPackages, actualPaths) {
+				t.Errorf("Expected paths %v but got %v", tc.expectedPackages, actualPaths)
+			}
+		})
+	}
+}

--- a/importer/test_packages/a/a.go
+++ b/importer/test_packages/a/a.go
@@ -1,0 +1,19 @@
+package a
+
+import (
+	"p"
+
+	"github.com/alecholmes/tdiff/importer/test_packages/a/aa/aaa"
+	"github.com/alecholmes/tdiff/importer/test_packages/b"
+)
+
+func Do() {
+	// Package p from vendor/p
+	// fmt.Println(new(p.Thing).Outer())
+	new(p.Thing).Outer()
+
+	// Package p from a/aa/aaa/vendor/p
+	aaa.GetThing().Nested()
+
+	b.Hello()
+}

--- a/importer/test_packages/a/aa/aaa/aaa.go
+++ b/importer/test_packages/a/aa/aaa/aaa.go
@@ -1,0 +1,9 @@
+package aaa
+
+import (
+	"p"
+)
+
+func GetThing() *p.Thing {
+	return new(p.Thing)
+}

--- a/importer/test_packages/a/aa/aaa/aaa_test.go
+++ b/importer/test_packages/a/aa/aaa/aaa_test.go
@@ -1,0 +1,23 @@
+package aaa
+
+import (
+	"p"
+
+	"github.com/alecholmes/tdiff/importer/test_packages/b"
+)
+
+// func TestAAA(t *testing.T) {
+// 	thing := new(p.Thing)
+// 	// fmt.Println(thing.Nested())
+// 	thing.Nested()
+
+// 	b.Hello()
+// }
+
+func helper() {
+	thing := new(p.Thing)
+	// fmt.Println(thing.Nested())
+	thing.Nested()
+
+	b.Hello()
+}

--- a/importer/test_packages/a/aa/aaa/vendor/p/p_aaa.go
+++ b/importer/test_packages/a/aa/aaa/vendor/p/p_aaa.go
@@ -1,0 +1,9 @@
+package p
+
+type Thing struct {
+	Inner int
+}
+
+func (t *Thing) Nested() string {
+	return "Nested"
+}

--- a/importer/test_packages/b/b.go
+++ b/importer/test_packages/b/b.go
@@ -1,0 +1,8 @@
+package b
+
+import "unsafe"
+
+func Hello() *unsafe.Pointer {
+	return new(unsafe.Pointer)
+
+}

--- a/importer/test_packages/vendor/p/p.go
+++ b/importer/test_packages/vendor/p/p.go
@@ -1,0 +1,9 @@
+package p
+
+type Thing struct {
+	value string
+}
+
+func (t *Thing) Outer() string {
+	return "Outer"
+}


### PR DESCRIPTION
Instead of using `go list` to determine relevant packages, an importer using the Go stdlib builds a graph of packages. This is used to expose how a changed package is reachable from the given root package.